### PR TITLE
proxy support and a bug fix

### DIFF
--- a/lib/new_relic_api.rb
+++ b/lib/new_relic_api.rb
@@ -222,6 +222,7 @@ module NewRelicApi
   #   NewRelicApi::Deployment.create :app_name => "My Application", :description => "Update production", :user => "Big Mike"
   #
   class Deployment < BaseResource
+    self.format = ActiveResource::Formats::XmlFormat
   end
 
   class Subscription < BaseResource


### PR DESCRIPTION
Hi,

Following are two fixes I have done when using newrelic api:
- proxy support
- a weird bug that from one user, the deployment message always sent to "http://rpm.newrelic.com:80/deployments.json" and got 404 error, while it is okay for others using the correct URL ("http://rpm.newrelic.com:80/deployments.xml"). So I have added a force extension
