### PR TITLE
fixes active resource 3.1 compatibility

### DIFF
--- a/lib/new_relic_api.rb
+++ b/lib/new_relic_api.rb
@@ -74,6 +74,7 @@ module NewRelicApi
         NewRelicApi.proxy
       end
     end
+    self.format = ActiveResource::Formats::XmlFormat
     self.site = self.site_url
     self.proxy = self.proxy
   end


### PR DESCRIPTION
It would be a good idea to regression test to make sure this doesn't break anything for earlier versions of activeresource, since I've only tested it in our particular setup.
