### PR TITLE
gemspec references nonexistent file

### DIFF
--- a/newrelic_api.gemspec
+++ b/newrelic_api.gemspec
@@ -13,11 +13,11 @@ Gem::Specification.new do |s|
   s.description = "Use this gem to access New Relic application information via a REST api"
   s.email = "support@newrelic.com"
   s.extra_rdoc_files = [
-    "CHANGELOG.md",
+    "CHANGELOG",
     "README.rdoc"
   ]
   s.files = [
-    "CHANGELOG.md",
+    "CHANGELOG",
     "Gemfile",
     "Gemfile.lock",
     "LICENSE.txt",


### PR DESCRIPTION
the current gemspec file references README.md which has just been changed to README(-.md). This causes bundler to issue this warning:

```
newrelic_api at /path/to/ruby/1.8/bundler/gems/newrelic_api-bb7c52ddd108 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:`
  ["CHANGELOG.md"] are not files
```
