### PR TITLE
Fix XMLs and HTTP methods in README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -437,7 +437,7 @@ when you log in to {rpm.newrelic.com}[link:https://rpm.newrelic.com].
 
 This example uses curl to find servers that match "my-hostname".
 
-    curl -H "x-api-key:YOUR_API_KEY_HERE" -X PUT -d "name=my-hostname" https://api.newrelic.com/api/v1/accounts/1/servers/find.xml
+    curl -H "x-api-key:YOUR_API_KEY_HERE" -X POST -d "name=my-hostname" https://api.newrelic.com/api/v1/accounts/1/servers/find.xml
 
 Returned:
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -416,7 +416,7 @@ Sample data:
         <hostname>my-hostname-2.newrelic.com</hostname>
         <id type="integer">556</id>
       </server>
-    <server>
+    </servers>
 
 === Possible Error Conditions
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -480,7 +480,7 @@ Sample data:
       <server name="My Server" id="123456">
         <result>deleted</result>
       </server>
-    <server>
+    </servers>
 
 Or:
 
@@ -489,7 +489,7 @@ Or:
       <server name="My Server" id="123456">
         <result>failed</result>
       </server>
-    <server>
+    </servers>
 
 === Possible Error Conditions
 


### PR DESCRIPTION
I am adding Servers support to https://github.com/andrewgross/pyrelic and the project uses `newrelic_api` sample data from the README to create its tests. I copied and paste from README and found the broken XML.

Also, following the README I saw some inconsistencies in HTTP methods (i.e. PUT vs POST).
