### PR TITLE
Fix Deployment Notification documentation

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1383,7 +1383,7 @@ Exactly one of the following is required:
 
 Following are optional parameters:
 * <tt>deployment[changelog]</tt>: A list of changes for this deployment
-* <tt>deployment[description]</tt>: Text annotation for the deployment &mdash; notes for you
+* <tt>deployment[description]</tt>: Text annotation for the deployment -- notes for you
 * <tt>deployment[revision]</tt>: A revision number (e.g., git commit SHA)
 * <tt>deployment[user]</tt>: The name of the user/process that triggered this deployment
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -1382,9 +1382,9 @@ Exactly one of the following is required:
 * <tt>deployment[application_id]</tt>: The application id, found in the URL when viewing the application in RPM.
 
 Following are optional parameters:
-* <tt>deployment[changelog]</tt>: A list of changes for this deployment
 * <tt>deployment[description]</tt>: Text annotation for the deployment -- notes for you
 * <tt>deployment[revision]</tt>: A revision number (e.g., git commit SHA)
+* <tt>deployment[changelog]</tt>: A list of changes for this deployment
 * <tt>deployment[user]</tt>: The name of the user/process that triggered this deployment
 
 The optional fields may be set to anything you wish,

--- a/README.rdoc
+++ b/README.rdoc
@@ -1382,12 +1382,10 @@ Exactly one of the following is required:
 * <tt>deployment[application_id]</tt>: The application id, found in the URL when viewing the application in RPM.
 
 Following are optional parameters:
-* <tt>deployment[changelog]</tt> or <tt>deployment[changes]</tt>: A list of changes for this deployment
+* <tt>deployment[changelog]</tt>: A list of changes for this deployment
 * <tt>deployment[description]</tt>: Text annotation for the deployment &mdash; notes for you
 * <tt>deployment[revision]</tt>: A revision number (e.g., git commit SHA)
 * <tt>deployment[user]</tt>: The name of the user/process that triggered this deployment
-* <tt>deployment[appname]</tt>: Name of the application
-* <tt>deployment[environment]</tt>: The environment for this deployment
 
 The optional fields may be set to anything you wish,
 and are not validated.

--- a/lib/new_relic_api.rb
+++ b/lib/new_relic_api.rb
@@ -214,8 +214,8 @@ module NewRelicApi
   #
   # Following are optional parameters:
   # * <tt>description</tt>: Text annotation for the deployment -- notes for you
-  # * <tt>changelog</tt>: A list of changes for this deployment
   # * <tt>revision</tt>: A revision number (e.g., git commit SHA)
+  # * <tt>changelog</tt>: A list of changes for this deployment
   # * <tt>user</tt>: The name of the user/process that triggered this deployment
   #
   # ==Example

--- a/lib/new_relic_api.rb
+++ b/lib/new_relic_api.rb
@@ -213,8 +213,9 @@ module NewRelicApi
   # * <tt>application_id</tt>: The application id, found in the URL when viewing the application in RPM.
   #
   # Following are optional parameters:
-  # * <tt>description</tt>: Text annotation for the deployment &mdash; notes for you
+  # * <tt>description</tt>: Text annotation for the deployment -- notes for you
   # * <tt>changelog</tt>: A list of changes for this deployment
+  # * <tt>revision</tt>: A revision number (e.g., git commit SHA)
   # * <tt>user</tt>: The name of the user/process that triggered this deployment
   #
   # ==Example

--- a/test/integration/newrelic_api_test.rb
+++ b/test/integration/newrelic_api_test.rb
@@ -110,7 +110,7 @@ class NewrelicApiTest < ActiveSupport::TestCase
 
     should "deploy" do
       # lookup an app by name
-      deployment = NewRelicApi::Deployment.create :appname => 'gold app'
+      deployment = NewRelicApi::Deployment.create :app_name => 'gold app'
       assert deployment.valid?, deployment.inspect
 
       # lookup an app by name
@@ -122,7 +122,7 @@ class NewrelicApiTest < ActiveSupport::TestCase
       application_id = apps.first.id
 
       # lookup by id won't work with appname
-      deployment = NewRelicApi::Deployment.create :appname => application_id
+      deployment = NewRelicApi::Deployment.create :app_name => application_id
       assert !deployment.valid?, deployment.inspect
 
       # lookup by id works with application_id


### PR DESCRIPTION
This is my attempt to correct the various inconsistent / incomplete / incorrect online documentation sources for New Relic Deployments, which confused me when I tried to use this API.

I am using the internal New Relic **How-to: track deployments with New Relic** /deployments/instructions as a master reference.
- added `revision` to the rdoc as it was missing from http://newrelic.github.io/newrelic_api/NewRelicApi/Deployment.html
- removed `environment` and `changes` from the README because they were not documented elsewhere, and didn't appear to be recognised by the API when I tested them
- removed `appname` from the README and tests, because even though it works, it isn't documented in the How To and `app_name` seems to be the preferred name as used elsewhere

Unrelated to this PR specifically, I had to do major surgery on the Gemfile + lock to get the tests to run at all, and two of the tests fail because the integration server test app is not returning any threshold values.

e.g.:
`curl -H "x-api-key:8022da2f6d143de67e056741262a054547b43479" "https://api.newrelic.com/api/v1/accounts.xml?include=application_health"`

returns:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<accounts type="array">
  <account>
    <id type="integer">128523602</id>
    <name>Gold</name>
    <event-feed-uri>/account_feeds/8022da2f6d143de67e056741262a054547b43479000/events.rss</event-feed-uri>
    <applications type="array">
      <application>
        <id type="integer">449331907</id>
        <name>gold app</name>
        <overview-url>https://test.local/accounts/128523602/applications/449331907</overview-url>
        <servers-url>https://test.local/api/v1/accounts/128523602/applications/449331907/servers</servers-url>
        <threshold-values type="array">
        </threshold-values>
      </application>
    </applications>
  </account>
</accounts>
```
