### PR TITLE
Add .xml on the end of the URL for Delete servers

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -461,7 +461,7 @@ Returned:
 
 == Delete servers
 
-URL::            <code>https://api.newrelic.com/api/v1/accounts/:account_id/servers/:id</code>
+URL::            <code>https://api.newrelic.com/api/v1/accounts/:account_id/servers/:id.xml</code>
 Method::         DELETE
 Restrictions::   None
 


### PR DESCRIPTION
Documentation misleading, omitting .xml on the end of the URL results in an 'HTTP/1.1 406 Not Acceptable' error.
